### PR TITLE
Fix field name used for saving invoices

### DIFF
--- a/app/api/erzeuge-abrechnung/route.ts
+++ b/app/api/erzeuge-abrechnung/route.ts
@@ -129,15 +129,19 @@ const pdfBuffer = await generateTrainerPDF({
     const publicUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/pdfs/${filename}`;
     console.log("[DEBUG] PDF URL:", publicUrl);
 
-    const { error: insertError } = await supabaseAdmin.from("monatsabrechnungen").upsert([{
-      trainername,
-      monat,
-      jahr,
-      status: "erstellt",
-      pdf_url: publicUrl,
-      summe,
-      erstell_am: new Date().toISOString(),
-    }]);
+    const { error: insertError } = await supabaseAdmin
+      .from("monatsabrechnungen")
+      .upsert([
+        {
+          trainername,
+          monat,
+          jahr,
+          status: "erstellt",
+          pdf_url: publicUrl,
+          summe,
+          erstellt_am: new Date().toISOString(),
+        },
+      ]);
 
     if (insertError) {
       console.error("[UPSERT-ERROR]", insertError.message);


### PR DESCRIPTION
## Summary
- fix typo when inserting invoice metadata so `erstellt_am` is used consistently

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683ff061e8b4832ea6564ad7b43f025a