### PR TITLE
Fix bis calculation with Date

### DIFF
--- a/app/api/erzeuge-abrechnung/route.ts
+++ b/app/api/erzeuge-abrechnung/route.ts
@@ -28,7 +28,9 @@ export async function POST(req: Request) {
     console.log("[DEBUG] Eingangsdaten:", trainername, monat, jahr);
 
     const von = `${jahr}-${String(monat).padStart(2, "0")}-01`;
-    const bis = `${jahr}-${String(monat + 1).padStart(2, "0")}-01`;
+    const bisDate = new Date(Number(jahr), Number(monat), 1);
+    bisDate.setMonth(bisDate.getMonth() + 1);
+    const bis = bisDate.toISOString().split("T")[0];
 
    // 1. Normale Einträge
 const { data: eintraegeRaw, error: err1 } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- compute `bis` date using a Date object in `erzeuge-abrechnung` route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841694d8ecc832eb93d8dbbf941b4a0