### PR TITLE
Use centralized SPARTEN constant in forms

### DIFF
--- a/app/admin/korrekturen/page.tsx
+++ b/app/admin/korrekturen/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabaseClient";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { SPARTEN } from "@/lib/constants";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -192,10 +193,11 @@ useEffect(() => {
         <Select value={formData.sparte} onValueChange={(val) => setFormData({ ...formData, sparte: val })}>
           <SelectTrigger><SelectValue placeholder="Sparte wählen" /></SelectTrigger>
           <SelectContent>
-            <SelectItem value="Judo">Judo</SelectItem>
-            <SelectItem value="Kinderturnen">Kinderturnen</SelectItem>
-            <SelectItem value="Zirkeltraining">Zirkeltraining</SelectItem>
-            <SelectItem value="Eltern-Kind-Turnen">Eltern-Kind-Turnen</SelectItem>
+            {SPARTEN.map((sparte) => (
+              <SelectItem key={sparte} value={sparte}>
+                {sparte}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,6 +11,7 @@ import { capitalize } from "@/lib/utils/capitalize";
 import { berechneVerguetung } from "@/lib/utils/berechneVerguetung";
 import { pruefeKonflikte } from "@/lib/utils/pruefeKonflikte";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { SPARTEN } from "@/lib/constants";
 import { useRouter } from "next/navigation";
 import dayjs from "dayjs";
 import "dayjs/locale/de";
@@ -214,12 +215,11 @@ useEffect(() => {
         <Select value={editEntry.sparte} onValueChange={(val) => setEditEntry({ ...editEntry, sparte: val })}>
   <SelectTrigger><SelectValue placeholder="Sparte" /></SelectTrigger>
   <SelectContent>
-    <SelectItem value="Judo">Judo</SelectItem>
-    <SelectItem value="Kinderturnen">Kinderturnen</SelectItem>
-    <SelectItem value="Zirkeltraining">Zirkeltraining</SelectItem>
-    <SelectItem value="Eltern-Kind-Turnen">Eltern-Kind-Turnen</SelectItem>
-    <SelectItem value="Leistungsturnen">Leistungsturnen</SelectItem>
-    <SelectItem value="Turntraining im Parcours">Turntraining im Parcours</SelectItem>
+    {SPARTEN.map((sparte) => (
+      <SelectItem key={sparte} value={sparte}>
+        {sparte}
+      </SelectItem>
+    ))}
   </SelectContent>
 </Select>
         <Input type="time" value={editEntry.beginn} onChange={(e) => setEditEntry({ ...editEntry, beginn: e.target.value })} />
@@ -285,12 +285,11 @@ useEffect(() => {
             <SelectTrigger><SelectValue placeholder="Alle Sparten" /></SelectTrigger>
             <SelectContent>
               <SelectItem value="alle">Alle</SelectItem>
-              <SelectItem value="Judo">Judo</SelectItem>
-              <SelectItem value="Kinderturnen">Kinderturnen</SelectItem>
-              <SelectItem value="Zirkeltraining">Zirkeltraining</SelectItem>
-              <SelectItem value="Eltern-Kind-Turnen">Eltern-Kind-Turnen</SelectItem>
-              <SelectItem value="Leistungsturnen">Leistungsturnen</SelectItem>
-              <SelectItem value="Turntraining im Parcours">Turntraining im Parcours</SelectItem>
+              {SPARTEN.map((sparte) => (
+                <SelectItem key={sparte} value={sparte}>
+                  {sparte}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -424,12 +423,11 @@ const key = `${e.trainername}_${monat}_${jahr}`;
           <Select value={newEntry.sparte} onValueChange={(val) => handleNewChange("sparte", val)}>
             <SelectTrigger><SelectValue placeholder="Sparte" /></SelectTrigger>
             <SelectContent>
-              <SelectItem value="Judo">Judo</SelectItem>
-              <SelectItem value="Kinderturnen">Kinderturnen</SelectItem>
-              <SelectItem value="Zirkeltraining">Zirkeltraining</SelectItem>
-              <SelectItem value="Eltern-Kind-Turnen">Eltern-Kind-Turnen</SelectItem>
-              <SelectItem value="Leistungsturnen">Leistungsturnen</SelectItem>
-              <SelectItem value="Turntraining im Parcours">Turntraining im Parcours</SelectItem>
+              {SPARTEN.map((sparte) => (
+                <SelectItem key={sparte} value={sparte}>
+                  {sparte}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
           <Input type="time" placeholder="Beginn" value={newEntry.beginn} onChange={(e) => handleNewChange("beginn", e.target.value)} />

--- a/app/trainer/page.tsx
+++ b/app/trainer/page.tsx
@@ -20,6 +20,7 @@ import { format, parseISO } from "date-fns";
 import { de } from "date-fns/locale";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
+import { SPARTEN } from "@/lib/constants";
 
 type Abrechnungseintrag = {
   id: string;
@@ -177,12 +178,11 @@ export default function TrainerAbrechnung() {
                 <Select value={formData.sparte} onValueChange={(val) => setFormData({ ...formData, sparte: val })}>
                   <SelectTrigger><SelectValue placeholder="Sparte wählen" /></SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Judo">Judo</SelectItem>
-                    <SelectItem value="Eltern-Kind-Turnen">Eltern-Kind-Turnen</SelectItem>
-                    <SelectItem value="Zirkeltraining">Zirkeltraining</SelectItem>
-                    <SelectItem value="Kinderturnen">Kinderturnen</SelectItem>
-                    <SelectItem value="Leistungsturnen">Leistungsturnen</SelectItem>
-                    <SelectItem value="Turntraining im Parcours">Turntraining im Parcours</SelectItem>
+                    {SPARTEN.map((sparte) => (
+                      <SelectItem key={sparte} value={sparte}>
+                        {sparte}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,8 @@
+export const SPARTEN = [
+  "Judo",
+  "Kinderturnen",
+  "Zirkeltraining",
+  "Eltern-Kind-Turnen",
+  "Leistungsturnen",
+  "Turntraining im Parcours",
+];


### PR DESCRIPTION
## Summary
- add `lib/constants.ts` exporting shared array `SPARTEN`
- use that array to populate sparte select options in the admin, trainer and correction forms

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174d4a838832e8090925445d06576