### PR TITLE
Add confirmation dialog for destructive actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,32 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Bestätigungsdialog verwenden
+
+Für Lösch- oder Reset-Aktionen steht ein wiederverwendbarer Bestätigungsdialog zur Verfügung. Dazu muss der globale Layout-Wrapper mit `ConfirmProvider` versehen werden:
+
+```tsx
+import { ConfirmProvider } from "@/components/ConfirmDialog";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ConfirmProvider>
+      {children}
+    </ConfirmProvider>
+  );
+}
+```
+
+Innerhalb von Client-Komponenten kannst du anschließend `useConfirm` aufrufen und auf die Bestätigung warten:
+
+```tsx
+import { useConfirm } from "@/components/ConfirmDialog";
+
+async function handleDelete() {
+  const ok = await useConfirm({ message: "Eintrag wirklich löschen?" });
+  if (ok) {
+    // ... Supabase-Operation ausführen
+  }
+}
+```

--- a/app/admin/abrechnungen/page.tsx
+++ b/app/admin/abrechnungen/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";
+import { useConfirm } from "@/components/ConfirmDialog";
 import dayjs from "dayjs";
 import "dayjs/locale/de";
 dayjs.locale("de");
@@ -42,6 +43,8 @@ export default function AdminAbrechnungenPage() {
   const [filterTrainer, setFilterTrainer] = useState<string>("alle");
   const [filterMonat, setFilterMonat] = useState<number | null>(null);
   const [filterJahr, setFilterJahr] = useState<number | null>(null);
+
+  const confirm = useConfirm();
 
 const gefilterteAbrechnungen = abrechnungen.filter((a) => {
   return (
@@ -102,7 +105,7 @@ const summe = gefilterteAbrechnungen.reduce((acc, a) => acc + (a.summe || 0), 0)
 }
 };
 const resetAbrechnung = async (trainername: string, monat: number, jahr: number) => {
-  const confirmed = confirm("Abrechnung wirklich zurücksetzen und PDF löschen?");
+  const confirmed = await confirm({ message: "Abrechnung wirklich zurücksetzen und PDF löschen?" });
   if (!confirmed) return;
 
   const { data } = await supabase

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,6 +12,7 @@ import { berechneVerguetung } from "@/lib/utils/berechneVerguetung";
 import { pruefeKonflikte } from "@/lib/utils/pruefeKonflikte";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { useRouter } from "next/navigation";
+import { useConfirm } from "@/components/ConfirmDialog";
 import dayjs from "dayjs";
 import "dayjs/locale/de";
 dayjs.locale("de");
@@ -70,6 +71,7 @@ export default function AdminPage() {
     trainername: ""
   });
   const router = useRouter();
+  const confirm = useConfirm();
   
   useEffect(() => {
     const checkUser = async () => {
@@ -161,7 +163,7 @@ useEffect(() => {
 }, [isAdmin]);
 
   const handleDelete = async (id: string) => {
-    const confirmed = confirm("Wirklich löschen?");
+    const confirmed = await confirm({ message: "Wirklich löschen?" });
     if (!confirmed) return;
     await supabase.from("abrechnungen").delete().eq("id", id);
     fetchData();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import { ConfirmProvider } from "@/components/ConfirmDialog";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,8 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
-        <Toaster position="top-center" richColors />
+        <ConfirmProvider>
+          {children}
+          <Toaster position="top-center" richColors />
+        </ConfirmProvider>
       </body>
     </html>
   );

--- a/app/trainer/abrechnungen/page.tsx
+++ b/app/trainer/abrechnungen/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabaseClient";
 import RequireAuth from "@/components/RequireAuth";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { toast } from "sonner";
 
 type Abrechnung = {
@@ -22,12 +23,12 @@ const MONATSNAMEN = [
 ];
 
 export default function MeineAbrechnungen() {
-    
+  const confirm = useConfirm();
 
   const [abrechnungen, setAbrechnungen] = useState<Abrechnung[]>([]);
   const [loading, setLoading] = useState(true);
   const freigeben = async (id: string) => {
-  const confirmed = confirm("Abrechnung jetzt freigeben?");
+  const confirmed = await confirm({ message: "Abrechnung jetzt freigeben?" });
   if (!confirmed) return;
 
   const { error } = await supabase

--- a/app/trainer/page.tsx
+++ b/app/trainer/page.tsx
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 import { format, parseISO } from "date-fns";
 import { de } from "date-fns/locale";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { useRouter } from "next/navigation";
 
 type Abrechnungseintrag = {
@@ -117,8 +118,10 @@ export default function TrainerAbrechnung() {
     }
   };
 
+  const confirm = useConfirm();
+
   const handleDelete = async (id: string) => {
-    const confirmed = window.confirm("Diesen Eintrag wirklich löschen?");
+    const confirmed = await confirm({ message: "Diesen Eintrag wirklich löschen?" });
     if (!confirmed) return;
     const { error } = await supabase.from("abrechnungen").delete().eq("id", id);
     if (error) {

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ConfirmOptions {
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+type ConfirmFunction = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFunction | null>(null);
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [options, setOptions] = useState<ConfirmOptions | null>(null);
+  const [resolver, setResolver] = useState<(value: boolean) => void>();
+
+  const confirm: ConfirmFunction = (opts) => {
+    return new Promise<boolean>((resolve) => {
+      setOptions({
+        title: "Bestätigen",
+        cancelText: "Abbrechen",
+        confirmText: "OK",
+        ...opts,
+      });
+      setResolver(() => resolve);
+    });
+  };
+
+  const handleClose = (result: boolean) => {
+    if (resolver) resolver(result);
+    setOptions(null);
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <Dialog open={!!options} onOpenChange={(open) => !open && handleClose(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{options?.title}</DialogTitle>
+          </DialogHeader>
+          <p>{options?.message}</p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleClose(false)}>
+              {options?.cancelText}
+            </Button>
+            <Button variant="destructive" onClick={() => handleClose(true)}>
+              {options?.confirmText}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </ConfirmContext.Provider>
+  );
+}
+
+export function useConfirm() {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error("useConfirm must be used within ConfirmProvider");
+  return ctx;
+}

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useState, ReactNode } from "react";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -15,7 +17,7 @@ const ConfirmContext = createContext<ConfirmFunction | null>(null);
 
 export function ConfirmProvider({ children }: { children: ReactNode }) {
   const [options, setOptions] = useState<ConfirmOptions | null>(null);
-  const [resolver, setResolver] = useState<(value: boolean) => void>();
+  const [resolver, setResolver] = useState<((value: boolean) => void) | undefined>();
 
   const confirm: ConfirmFunction = (opts) => {
     return new Promise<boolean>((resolve) => {
@@ -31,6 +33,7 @@ export function ConfirmProvider({ children }: { children: ReactNode }) {
 
   const handleClose = (result: boolean) => {
     if (resolver) resolver(result);
+    setResolver(undefined);
     setOptions(null);
   };
 


### PR DESCRIPTION
## Summary
- add reusable `ConfirmDialog` component using Radix dialog
- wrap layout with `ConfirmProvider`
- replace browser `confirm` calls with `useConfirm` in admin and trainer pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174d6e570832eaf00fe865a36351f