### PR TITLE
update admin state after pdf actions

### DIFF
--- a/app/admin/abrechnungen/page.tsx
+++ b/app/admin/abrechnungen/page.tsx
@@ -51,12 +51,14 @@ const gefilterteAbrechnungen = abrechnungen.filter((a) => {
   );
 });
 
-const summe = gefilterteAbrechnungen.reduce((acc, a) => acc + (a.summe || 0), 0);
+  const summe = gefilterteAbrechnungen.reduce((acc, a) => acc + (a.summe || 0), 0);
+
+  const fetchAbrechnungen = async () => {
+    const { data } = await supabase.from("monatsabrechnungen").select("*");
+    if (data) setAbrechnungen(data);
+  };
+
   useEffect(() => {
-    const fetchAbrechnungen = async () => {
-      const { data } = await supabase.from("monatsabrechnungen").select("*");
-      if (data) setAbrechnungen(data);
-    };
     fetchAbrechnungen();
   }, []);
 
@@ -91,7 +93,7 @@ const summe = gefilterteAbrechnungen.reduce((acc, a) => acc + (a.summe || 0), 0)
       .eq("jahr", jahr);
 
     toast.success("PDF erfolgreich erstellt ✅");
-    location.reload();
+    fetchAbrechnungen();
 
   } catch (err: unknown) {
   if (err instanceof Error) {
@@ -126,7 +128,7 @@ const resetAbrechnung = async (trainername: string, monat: number, jahr: number)
     .eq("jahr", jahr);
 
   toast.success("Abrechnung zurückgesetzt 🔁");
-  location.reload();
+  fetchAbrechnungen();
 };
 
 


### PR DESCRIPTION
## Summary
- update abrechnung list without reloading the page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174da58b8832e9506281bb496e014