### PR TITLE
Use enum for Abrechnungsstatus

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import dayjs from "dayjs";
 import "dayjs/locale/de";
 dayjs.locale("de");
+import { ABRECHNUNG_STATUS } from "@/lib/constants";
 
 type Satz = {
   funktion: string;
@@ -148,7 +149,7 @@ useEffect(() => {
     const { data } = await supabase
       .from("monatsabrechnungen")
       .select("monat,jahr,trainername")
-      .in("status", ["erstellt", "warten-auf-freigabe", "offen", "bezahlt"])
+      .in("status", ABRECHNUNG_STATUS)
 
     if (data) {
       const keyset = new Set<string>(

--- a/app/api/erzeuge-abrechnung/route.ts
+++ b/app/api/erzeuge-abrechnung/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { generateTrainerPDF } from "@/lib/pdf/generateTrainerPDF";
 import { berechneVerguetung } from "@/lib/utils/berechneVerguetung";
+import { ABRECHNUNG_STATUS } from "@/lib/constants";
 
 
 export const dynamic = "force-dynamic";
@@ -135,7 +136,7 @@ const pdfBuffer = await generateTrainerPDF({
       trainername,
       monat,
       jahr,
-      status: "erstellt",
+      status: ABRECHNUNG_STATUS[1],
       pdf_url: publicUrl,
       summe,
       erstell_am: new Date().toISOString(),

--- a/app/trainer/abrechnungen/page.tsx
+++ b/app/trainer/abrechnungen/page.tsx
@@ -6,13 +6,14 @@ import RequireAuth from "@/components/RequireAuth";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { ABRECHNUNG_STATUS, type AbrechnungStatus } from "@/lib/constants";
 
 type Abrechnung = {
   id: string;
   trainername: string;
   monat: number;
   jahr: number;
-  status: string;
+  status: AbrechnungStatus;
   pdf_url: string;
 };
 
@@ -32,13 +33,13 @@ export default function MeineAbrechnungen() {
 
   const { error } = await supabase
     .from("monatsabrechnungen")
-    .update({ status: "offen", freigabe_am: new Date().toISOString() })
+    .update({ status: ABRECHNUNG_STATUS[0], freigabe_am: new Date().toISOString() })
     .eq("id", id);
 
   if (!error) {
     toast.success("Abrechnung freigegeben ✅");
     setAbrechnungen((prev) =>
-      prev.map((a) => a.id === id ? { ...a, status: "offen" } : a)
+      prev.map((a) => a.id === id ? { ...a, status: ABRECHNUNG_STATUS[0] } : a)
     );
   } else {
     toast.error("Fehler beim Freigeben ❌");
@@ -131,7 +132,7 @@ export default function MeineAbrechnungen() {
                           <span className="text-gray-400 italic">Noch nicht verfügbar</span>
                         )}
                       </td>
-                      {eintrag.status === "warten-auf-freigabe" && (
+                      {eintrag.status === ABRECHNUNG_STATUS[3] && (
   <td className="p-2">
     <Button size="sm" className="text-xs px-2 py-1" onClick={() => freigeben(eintrag.id)}>
       ✅ Freigeben?

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,8 @@
+export const ABRECHNUNG_STATUS = [
+  "offen",
+  "erstellt",
+  "bezahlt",
+  "warten-auf-freigabe",
+] as const;
+
+export type AbrechnungStatus = typeof ABRECHNUNG_STATUS[number];


### PR DESCRIPTION
## Summary
- add `ABRECHNUNG_STATUS` constant
- use enum in admin and trainer pages
- use enum in API route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174ffe7e8832eb372601953829678