### PR TITLE
Refactor admin dashboard into components

### DIFF
--- a/app/admin/components/EditForm.tsx
+++ b/app/admin/components/EditForm.tsx
@@ -1,0 +1,125 @@
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { SPARTEN } from "@/lib/constants";
+import { Abrechnung } from "../page";
+
+interface EditFormProps {
+  entry: Abrechnung;
+  trainerList: string[];
+  setEntry: (e: Abrechnung) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+export default function EditForm({
+  entry,
+  trainerList,
+  setEntry,
+  onCancel,
+  onSave,
+}: EditFormProps) {
+  return (
+    <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-2xl space-y-4">
+        <h2 className="text-lg font-bold">Eintrag bearbeiten</h2>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <Input
+            type="date"
+            value={entry.datum}
+            onChange={(e) => setEntry({ ...entry, datum: e.target.value })}
+          />
+          <Select
+            value={entry.sparte}
+            onValueChange={(val) => setEntry({ ...entry, sparte: val })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Sparte" />
+            </SelectTrigger>
+            <SelectContent>
+              {SPARTEN.map((sparte) => (
+                <SelectItem key={sparte} value={sparte}>
+                  {sparte}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            type="time"
+            value={entry.beginn}
+            onChange={(e) => setEntry({ ...entry, beginn: e.target.value })}
+          />
+          <Input
+            type="time"
+            value={entry.ende}
+            onChange={(e) => setEntry({ ...entry, ende: e.target.value })}
+          />
+          <Select
+            value={entry.hallenfeld}
+            onValueChange={(val) => setEntry({ ...entry, hallenfeld: val })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Feld" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1">Feld 1</SelectItem>
+              <SelectItem value="2">Feld 2</SelectItem>
+              <SelectItem value="3">Feld 3</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={entry.funktion}
+            onValueChange={(val) => setEntry({ ...entry, funktion: val })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="trainer">Trainer</SelectItem>
+              <SelectItem value="hilfstrainer">Hilfstrainer</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={entry.aufbau ? "ja" : "nein"}
+            onValueChange={(val) => setEntry({ ...entry, aufbau: val === "ja" })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ja">Ja</SelectItem>
+              <SelectItem value="nein">Nein</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={entry.trainername}
+            onValueChange={(val) => setEntry({ ...entry, trainername: val })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Trainer" />
+            </SelectTrigger>
+            <SelectContent>
+              {trainerList.map((name) => (
+                <SelectItem key={name} value={name}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onCancel}>
+            Abbrechen
+          </Button>
+          <Button onClick={onSave}>Speichern</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/components/EntryList.tsx
+++ b/app/admin/components/EntryList.tsx
@@ -1,0 +1,160 @@
+import dayjs from "dayjs";
+import { berechneVerguetung } from "@/lib/utils/berechneVerguetung";
+import { pruefeKonflikte } from "@/lib/utils/pruefeKonflikte";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Abrechnung, Satz, Standardzeit } from "../page";
+
+interface EntryListProps {
+  entries: Abrechnung[];
+  saetze: Satz[];
+  sortAscending: boolean;
+  setSortAscending: (v: boolean) => void;
+  setEditEntry: (e: Abrechnung) => void;
+  handleDelete: (id: string) => void;
+  showAbgerechnete: boolean;
+  abgerechneteKeys: Set<string>;
+  ferienDaten: string[];
+  standardzeiten: Standardzeit[];
+}
+
+export default function EntryList({
+  entries,
+  saetze,
+  sortAscending,
+  setSortAscending,
+  setEditEntry,
+  handleDelete,
+  showAbgerechnete,
+  abgerechneteKeys,
+  ferienDaten,
+  standardzeiten,
+}: EntryListProps) {
+  return (
+    <Card>
+      <CardContent className="overflow-x-auto p-4">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th>Wochentag</th>
+              <th>
+                <button
+                  onClick={() => setSortAscending(!sortAscending)}
+                  className="underline"
+                >
+                  Datum {sortAscending ? "⬆️" : "⬇️"}
+                </button>
+              </th>
+              <th>Sparte</th>
+              <th>Beginn</th>
+              <th>Ende</th>
+              <th>Feld</th>
+              <th>Funktion</th>
+              <th>Aufbau</th>
+              <th>Trainer</th>
+              <th>Vergütung (€)</th>
+              <th>Konflikt</th>
+              <th>Aktion</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[...entries]
+              .sort((a, b) =>
+                sortAscending
+                  ? a.datum.localeCompare(b.datum)
+                  : b.datum.localeCompare(a.datum)
+              )
+              .filter((e) => {
+                const monat = new Date(e.datum).getMonth() + 1;
+                const jahr = new Date(e.datum).getFullYear();
+                const key = `${e.trainername}_${monat}_${jahr}`;
+                return showAbgerechnete || !abgerechneteKeys.has(key);
+              })
+              .map((e) => {
+                const datumObj = new Date(e.datum);
+                const monat = datumObj.getUTCMonth() + 1;
+                const jahr = datumObj.getUTCFullYear();
+                const key = `${e.trainername}_${monat}_${jahr}`;
+                const konflikte = pruefeKonflikte(
+                  e,
+                  entries,
+                  ferienDaten,
+                  standardzeiten
+                );
+                const istAbgerechnet = abgerechneteKeys.has(key);
+                return (
+                  <tr
+                    key={e.id}
+                    className={`border-b hover:bg-gray-50 ${
+                      istAbgerechnet ? "bg-yellow-50" : ""
+                    }`}
+                  >
+                    <td>{dayjs(e.datum).format("dddd")}</td>
+                    <td>{e.datum}</td>
+                    <td>{e.sparte}</td>
+                    <td>{e.beginn}</td>
+                    <td>{e.ende}</td>
+                    <td>{e.hallenfeld}</td>
+                    <td>{e.funktion}</td>
+                    <td>{e.aufbau ? "Ja" : "Nein"}</td>
+                    <td>{e.trainername}</td>
+                    <td>
+                      {berechneVerguetung(
+                        e.beginn,
+                        e.ende,
+                        e.aufbau,
+                        e.funktion,
+                        e.datum.split("T")[0],
+                        saetze
+                      ).toFixed(2)}
+                    </td>
+                    <td className="text-red-600">
+                      {konflikte.length > 0 && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="cursor-help underline decoration-dotted">
+                                ⚠ {konflikte.length} Konflikt{konflikte.length !== 1 ? "e" : ""}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <ul className="text-xs max-w-xs space-y-1">
+                                {konflikte.map((k, i) => (
+                                  <li key={i}>{k}</li>
+                                ))}
+                              </ul>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                    </td>
+                    <td className="space-x-2">
+                      {!istAbgerechnet && (
+                        <>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setEditEntry(e)}
+                          >
+                            Bearbeiten
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => handleDelete(e.id)}
+                          >
+                            Löschen
+                          </Button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/components/FilterBar.tsx
+++ b/app/admin/components/FilterBar.tsx
@@ -1,0 +1,89 @@
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { SPARTEN } from "@/lib/constants";
+
+interface FilterBarProps {
+  filterMonat: string;
+  onFilterMonatChange: (val: string) => void;
+  filterSparte: string;
+  onFilterSparteChange: (val: string) => void;
+  filterTrainer: string;
+  onFilterTrainerChange: (val: string) => void;
+  showAbgerechnete: boolean;
+  onToggleShowAbgerechnete: () => void;
+  trainerList: string[];
+}
+
+export default function FilterBar({
+  filterMonat,
+  onFilterMonatChange,
+  filterSparte,
+  onFilterSparteChange,
+  filterTrainer,
+  onFilterTrainerChange,
+  showAbgerechnete,
+  onToggleShowAbgerechnete,
+  trainerList,
+}: FilterBarProps) {
+  return (
+    <div className="flex gap-4 mb-6 flex-wrap">
+      <div>
+        <Label>Monat</Label>
+        <Input
+          type="month"
+          value={filterMonat}
+          onChange={(e) => onFilterMonatChange(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label>Sparte</Label>
+        <Select value={filterSparte} onValueChange={onFilterSparteChange}>
+          <SelectTrigger>
+            <SelectValue placeholder="Alle Sparten" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="alle">Alle</SelectItem>
+            {SPARTEN.map((sparte) => (
+              <SelectItem key={sparte} value={sparte}>
+                {sparte}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="mb-4">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showAbgerechnete}
+            onChange={onToggleShowAbgerechnete}
+          />
+          <span>Auch bereits abgerechnete Einträge anzeigen</span>
+        </label>
+      </div>
+      <div>
+        <Label>Trainer</Label>
+        <Select value={filterTrainer} onValueChange={onFilterTrainerChange}>
+          <SelectTrigger>
+            <SelectValue placeholder="Alle Trainer" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="alle">Alle</SelectItem>
+            {trainerList.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -14,18 +14,21 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { SPARTEN } from "@/lib/constants";
 import { useRouter } from "next/navigation";
 import { useConfirm } from "@/components/ConfirmDialog";
+import FilterBar from "./components/FilterBar";
+import EntryList from "./components/EntryList";
+import EditForm from "./components/EditForm";
 import dayjs from "dayjs";
 import "dayjs/locale/de";
 dayjs.locale("de");
 
-type Satz = {
+export type Satz = {
   funktion: string;
   stundenlohn: number;
   aufbau_bonus: number;
   gültig_ab: string;
 };
 
-type Abrechnung = {
+export type Abrechnung = {
   id: string;
   datum: string;
   sparte: string;
@@ -36,7 +39,7 @@ type Abrechnung = {
   aufbau: boolean;
   trainername: string;
 };
-type Standardzeit = {
+export type Standardzeit = {
   sparte: string;
   wochentag: number;
   beginn: string;
@@ -207,216 +210,52 @@ useEffect(() => {
   return (
     <div className="p-6 max-w-6xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Admin-Dashboard</h1>
-{editEntry && (
-  <div className="fixed inset-0 bg-white bg-opacity-80 backdrop-blur-sm flex justify-center items-center z-50">
-    <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-2xl space-y-4">
-      <h2 className="text-lg font-bold">Eintrag bearbeiten</h2>
+      {editEntry && (
+        <EditForm
+          entry={editEntry}
+          trainerList={trainerList}
+          setEntry={setEditEntry}
+          onCancel={() => setEditEntry(null)}
+          onSave={async () => {
+            if (!editEntry) return;
+            const { error } = await supabase
+              .from("abrechnungen")
+              .update({ ...editEntry, funktion: capitalize(editEntry.funktion) })
+              .eq("id", editEntry.id);
+            if (!error) {
+              setEditEntry(null);
+              fetchData();
+            } else {
+              alert("Fehler beim Speichern");
+              console.error(error);
+            }
+          }}
+        />
+      )}
+      <FilterBar
+        filterMonat={filterMonat}
+        onFilterMonatChange={setFilterMonat}
+        filterSparte={filterSparte}
+        onFilterSparteChange={setFilterSparte}
+        filterTrainer={filterTrainer}
+        onFilterTrainerChange={setFilterTrainer}
+        showAbgerechnete={showAbgerechnete}
+        onToggleShowAbgerechnete={() => setShowAbgerechnete((v) => !v)}
+        trainerList={trainerList}
+      />
 
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-        <Input type="date" value={editEntry.datum} onChange={(e) => setEditEntry({ ...editEntry, datum: e.target.value })} />
-        <Select value={editEntry.sparte} onValueChange={(val) => setEditEntry({ ...editEntry, sparte: val })}>
-  <SelectTrigger><SelectValue placeholder="Sparte" /></SelectTrigger>
-  <SelectContent>
-    {SPARTEN.map((sparte) => (
-      <SelectItem key={sparte} value={sparte}>
-        {sparte}
-      </SelectItem>
-    ))}
-  </SelectContent>
-</Select>
-        <Input type="time" value={editEntry.beginn} onChange={(e) => setEditEntry({ ...editEntry, beginn: e.target.value })} />
-        <Input type="time" value={editEntry.ende} onChange={(e) => setEditEntry({ ...editEntry, ende: e.target.value })} />
-        <Select value={editEntry.hallenfeld} onValueChange={(val) => setEditEntry({ ...editEntry, hallenfeld: val })}>
-  <SelectTrigger><SelectValue placeholder="Feld" /></SelectTrigger>
-  <SelectContent>
-    <SelectItem value="1">Feld 1</SelectItem>
-    <SelectItem value="2">Feld 2</SelectItem>
-    <SelectItem value="3">Feld 3</SelectItem>
-  </SelectContent>
-</Select>
-        <Select value={editEntry.funktion} onValueChange={(val) => setEditEntry({ ...editEntry, funktion: val })}>
-          <SelectTrigger><SelectValue /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="trainer">Trainer</SelectItem>
-            <SelectItem value="hilfstrainer">Hilfstrainer</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select value={editEntry.aufbau ? "ja" : "nein"} onValueChange={(val) => setEditEntry({ ...editEntry, aufbau: val === "ja" })}>
-          <SelectTrigger><SelectValue /></SelectTrigger>
-          <SelectContent>
-            <SelectItem value="ja">Ja</SelectItem>
-            <SelectItem value="nein">Nein</SelectItem>
-          </SelectContent>
-        </Select>
-       <Select value={editEntry.trainername} onValueChange={(val) => setEditEntry({ ...editEntry, trainername: val })}>
-  <SelectTrigger><SelectValue placeholder="Trainer" /></SelectTrigger>
-  <SelectContent>
-    {trainerList.map((name) => (
-      <SelectItem key={name} value={name}>{name}</SelectItem>
-    ))}
-  </SelectContent>
-</Select>
-      </div>
-
-      <div className="flex justify-end gap-2">
-        <Button variant="secondary" onClick={() => setEditEntry(null)}>Abbrechen</Button>
-        <Button onClick={async () => {
-          const { error } = await supabase.from("abrechnungen")
-            .update({ ...editEntry, funktion: capitalize(editEntry.funktion) })
-            .eq("id", editEntry.id);
-          if (!error) {
-            setEditEntry(null);
-            fetchData();
-          } else {
-            alert("Fehler beim Speichern");
-            console.error(error);
-          }
-        }}>Speichern</Button>
-      </div>
-    </div>
-  </div>
-)}
-      <div className="flex gap-4 mb-6 flex-wrap">
-        <div>
-          <Label>Monat</Label>
-          <Input type="month" value={filterMonat} onChange={(e) => setFilterMonat(e.target.value)} />
-        </div>
-        <div>
-          <Label>Sparte</Label>
-          <Select value={filterSparte} onValueChange={setFilterSparte}>
-            <SelectTrigger><SelectValue placeholder="Alle Sparten" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="alle">Alle</SelectItem>
-              {SPARTEN.map((sparte) => (
-                <SelectItem key={sparte} value={sparte}>
-                  {sparte}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="mb-4">
-  <label className="inline-flex items-center gap-2">
-    <input
-      type="checkbox"
-      checked={showAbgerechnete}
-      onChange={() => setShowAbgerechnete((v) => !v)}
-    />
-    <span>Auch bereits abgerechnete Einträge anzeigen</span>
-  </label>
-</div>
-
-        <div>
-          <Label>Trainer</Label>
-          <Select value={filterTrainer} onValueChange={setFilterTrainer}>
-            <SelectTrigger><SelectValue placeholder="Alle Trainer" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="alle">Alle</SelectItem>
-              {trainerList.map((name) => (
-                <SelectItem key={name} value={name}>{name}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      <Card>
-        <CardContent className="overflow-x-auto p-4">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left border-b">
-                <th>Wochentag</th>
-                <th>
-  <button onClick={() => setSortAscending(!sortAscending)} className="underline">
-    Datum {sortAscending ? "⬆️" : "⬇️"}
-  </button>
-</th>
-                <th>Sparte</th>
-                <th>Beginn</th>
-                <th>Ende</th>
-                <th>Feld</th>
-                <th>Funktion</th>
-                <th>Aufbau</th>
-                <th>Trainer</th>
-                <th>Vergütung (€)</th>
-                <th>Konflikt</th>
-                <th>Aktion</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...entries]
-  .sort((a, b) => sortAscending
-  ? a.datum.localeCompare(b.datum)
-  : b.datum.localeCompare(a.datum)
-)
-.filter((e) => {
-  const monat = new Date(e.datum).getMonth() + 1;
-  const jahr = new Date(e.datum).getFullYear();
-  const key = `${e.trainername}_${monat}_${jahr}`;
-  return showAbgerechnete || !abgerechneteKeys.has(key);
-})
-.map((e) => {
-  const datumObj = new Date(e.datum);
-const monat = datumObj.getUTCMonth() + 1;
-const konflikte = pruefeKonflikte(e, entries, ferienDaten, standardzeiten);
-
-const jahr = datumObj.getUTCFullYear();
-const key = `${e.trainername}_${monat}_${jahr}`;
-  const istAbgerechnet = abgerechneteKeys.has(key);
-
-  return (
-    <tr key={e.id} className={`border-b hover:bg-gray-50 ${istAbgerechnet ? "bg-yellow-50" : ""}`}>
-      <td>{dayjs(e.datum).format("dddd")}</td>
-      <td>{e.datum}</td>
-      <td>{e.sparte}</td>
-      <td>{e.beginn}</td>
-      <td>{e.ende}</td>
-      <td>{e.hallenfeld}</td>     
-      <td>{e.funktion}</td>
-      <td>{e.aufbau ? "Ja" : "Nein"}</td>
-      <td>{e.trainername}</td>
-      <td>{berechneVerguetung(e.beginn, e.ende, e.aufbau, e.funktion, e.datum.split("T")[0], saetze).toFixed(2)}</td>
-
-      <td className="text-red-600">
-  {konflikte.length > 0 && (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="cursor-help underline decoration-dotted">
-            ⚠ {konflikte.length} Konflikt{konflikte.length !== 1 ? "e" : ""}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <ul className="text-xs max-w-xs space-y-1">
-            {konflikte.map((k, i) => (
-              <li key={i}>{k}</li>
-            ))}
-          </ul>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )}
-</td>
-
-
-      <td className="space-x-2">
-  {!istAbgerechnet && (
-    <>
-      <Button size="sm" variant="outline" onClick={() => setEditEntry(e)}>Bearbeiten</Button>
-      <Button size="sm" variant="destructive" onClick={() => handleDelete(e.id)}>Löschen</Button>
-    </>
-  )}
-</td>
-
-    </tr>
-  );
-  
-})}
-
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
+      <EntryList
+        entries={entries}
+        saetze={saetze}
+        sortAscending={sortAscending}
+        setSortAscending={setSortAscending}
+        setEditEntry={setEditEntry}
+        handleDelete={handleDelete}
+        showAbgerechnete={showAbgerechnete}
+        abgerechneteKeys={abgerechneteKeys}
+        ferienDaten={ferienDaten}
+        standardzeiten={standardzeiten}
+      />
 
       <div className="mt-6">
         <h2 className="text-lg font-bold mb-2">Neuen Eintrag hinzufügen</h2>


### PR DESCRIPTION
## Summary
- create `FilterBar`, `EntryList` and `EditForm` under `app/admin/components`
- export types from admin page and use new components
- simplify `app/admin/page.tsx` by delegating UI to components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fddf7c8c832eb9ef2dd60fa0445b