### PR TITLE
Add age limit check for member groups

### DIFF
--- a/lib/pruefeGruppenWechsel.ts
+++ b/lib/pruefeGruppenWechsel.ts
@@ -1,0 +1,72 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+import { differenceInYears, isValid } from "date-fns";
+
+/**
+ * Durchsucht alle Einträge der Tabelle `mitglied_gruppen` und
+ * prüft, ob das jeweilige Mitglied die Altersgrenze der Gruppe überschreitet.
+ * Bei Überschreitung werden entsprechende Felder gesetzt, so dass ein
+ * Gruppenwechsel vermerkt wird.
+ */
+export async function pruefeGruppenWechsel() {
+  console.log("[INFO] Starte Altersgrenzen-Prüfung");
+
+  const { data, error } = await supabaseAdmin
+    .from("mitglied_gruppen")
+    .select(
+      "id, mitglieder(id, vorname, nachname, geburtsdatum), gruppen(id, name, altersgrenze_max)"
+    );
+
+  if (error) {
+    console.error("[ERROR] Laden der Verknüpfungen fehlgeschlagen:", error.message);
+    throw error;
+  }
+
+  if (!data) {
+    console.log("[WARN] Keine Verknüpfungen gefunden");
+    return;
+  }
+
+  for (const eintrag of data) {
+    const mitglied = eintrag.mitglieder;
+    const gruppe = eintrag.gruppen;
+
+    if (!mitglied || !gruppe || gruppe.altersgrenze_max === null) {
+      continue;
+    }
+
+    const geburt = new Date(mitglied.geburtsdatum);
+    if (!isValid(geburt)) {
+      console.warn(`[WARN] Ungültiges Geburtsdatum bei Mitglied ${mitglied.id}`);
+      continue;
+    }
+
+    const alter = differenceInYears(new Date(), geburt);
+    if (alter > gruppe.altersgrenze_max) {
+      console.log(
+        `[INFO] ${mitglied.vorname} ${mitglied.nachname} (${alter} Jahre) überschreitet ` +
+          `die Altersgrenze ${gruppe.altersgrenze_max} der Gruppe ${gruppe.name}`
+      );
+
+      const { error: updateError } = await supabaseAdmin
+        .from("mitglied_gruppen")
+        .update({
+          wechsel_erforderlich: true,
+          bereit_für_wechsel: null,
+          wechsel_geprüft: false,
+          wechsel_anmerkung: null,
+        })
+        .eq("id", eintrag.id);
+
+      if (updateError) {
+        console.error(
+          `[ERROR] Aktualisierung fehlgeschlagen (ID ${eintrag.id}):`,
+          updateError.message
+        );
+      } else {
+        console.log(`[INFO] Eintrag ${eintrag.id} aktualisiert.`);
+      }
+    }
+  }
+
+  console.log("[INFO] Altersgrenzen-Prüfung abgeschlossen");
+}

--- a/lib/pruefeGruppenWechsel.ts
+++ b/lib/pruefeGruppenWechsel.ts
@@ -1,6 +1,25 @@
 import { supabaseAdmin } from "./supabaseAdmin";
 import { differenceInYears, isValid } from "date-fns";
 
+interface Mitglied {
+  id: string;
+  vorname: string;
+  nachname: string;
+  geburtsdatum: string;
+}
+
+interface Gruppe {
+  id: string;
+  name: string;
+  altersgrenze_max: number | null;
+}
+
+interface MitgliedGruppeRow {
+  id: string;
+  mitglieder: Mitglied | null;
+  gruppen: Gruppe | Gruppe[] | null;
+}
+
 /**
  * Durchsucht alle Einträge der Tabelle `mitglied_gruppen` und
  * prüft, ob das jeweilige Mitglied die Altersgrenze der Gruppe überschreitet.
@@ -26,10 +45,14 @@ export async function pruefeGruppenWechsel() {
     return;
   }
 
-  for (const eintrag of data) {
-    const mitglied = eintrag.mitglieder as any;
-    const rawGruppe = eintrag.gruppen as any;
-    const gruppe = Array.isArray(rawGruppe) ? rawGruppe[0] : rawGruppe;
+  const rows = data as MitgliedGruppeRow[];
+
+  for (const eintrag of rows) {
+    const gruppeData = Array.isArray(eintrag.gruppen)
+      ? eintrag.gruppen[0]
+      : eintrag.gruppen;
+    const mitglied = eintrag.mitglieder;
+    const gruppe = gruppeData;
 
     if (!mitglied || !gruppe || gruppe.altersgrenze_max === null) {
       continue;

--- a/lib/pruefeGruppenWechsel.ts
+++ b/lib/pruefeGruppenWechsel.ts
@@ -27,8 +27,9 @@ export async function pruefeGruppenWechsel() {
   }
 
   for (const eintrag of data) {
-    const mitglied = eintrag.mitglieder;
-    const gruppe = eintrag.gruppen;
+    const mitglied = eintrag.mitglieder as any;
+    const rawGruppe = eintrag.gruppen as any;
+    const gruppe = Array.isArray(rawGruppe) ? rawGruppe[0] : rawGruppe;
 
     if (!mitglied || !gruppe || gruppe.altersgrenze_max === null) {
       continue;


### PR DESCRIPTION
## Summary
- add `pruefeGruppenWechsel` helper to scan `mitglied_gruppen` and update entries when the age limit of a group is exceeded

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e2e5cae80832eb1b02f7bcad79771